### PR TITLE
yaml is required to load the standalone Vagrantfile

### DIFF
--- a/standalone/Vagrantfile
+++ b/standalone/Vagrantfile
@@ -1,5 +1,7 @@
 # -*- mode: ruby -*-
 # vi: set ft=ruby :
+require 'yaml'
+
 ## vagrant plugins required:
 # vagrant-digitalocean, vagrant-aws, vagrant, vagrant-hosts, vagrant-cachier
 Vagrant.configure("2") do |config|


### PR DESCRIPTION
Vagrant cannot load the standalone Vagrantfile unless `yaml` is required:
```
There was an error loading a Vagrantfile. The file being loaded
and the error message are shown below. This is usually caused by
a syntax error.

Path: <provider config: digital_ocean>
Message: uninitialized constant YAML
```